### PR TITLE
const: refactor of member functions const qualifiers

### DIFF
--- a/include/vsp/session.h
+++ b/include/vsp/session.h
@@ -55,7 +55,7 @@ public:
     const string& vcml_version() const;
     unsigned long long time();
     unsigned long long cycle();
-    string reason();
+    const string& reason() const;
 
     bool is_connected() const;
     void connect();
@@ -73,7 +73,7 @@ public:
     command* find_command(const string& name);
     target* find_target(const string& name);
 
-    const list<target>& targets() const;
+    list<target>& targets();
 
     const char* peer() const;
     const char* host() const;

--- a/include/vsp/target.h
+++ b/include/vsp/target.h
@@ -47,8 +47,8 @@ public:
     bool write_vmem(u64 vaddr, const vector<u8>& data);
 
     bool pc(u64& pc);
-    const list<cpureg>& regs() const;
-    const cpureg* find_reg(const string& name) const;
+    list<cpureg>& regs();
+    cpureg* find_reg(const string& name);
 };
 
 } // namespace vsp

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -142,7 +142,7 @@ unsigned long long session::cycle() {
     return m_cycle;
 }
 
-string session::reason() {
+string session::reason() const {
     return m_reason;
 }
 

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -142,7 +142,7 @@ unsigned long long session::cycle() {
     return m_cycle;
 }
 
-string session::reason() const {
+const string& session::reason() const {
     return m_reason;
 }
 
@@ -255,7 +255,7 @@ target* session::find_target(const string& name) {
     return nullptr;
 }
 
-const list<target>& session::targets() const {
+list<target>& session::targets() {
     return m_targets;
 }
 

--- a/src/vsp/target.cpp
+++ b/src/vsp/target.cpp
@@ -135,11 +135,11 @@ bool target::pc(u64& pc) {
     return true;
 }
 
-const list<cpureg>& target::regs() const {
+list<cpureg>& target::regs() {
     return m_regs;
 }
 
-const cpureg* target::find_reg(const string& name) const {
+cpureg* target::find_reg(const string& name) {
     for (auto& reg : m_regs) {
         if (strcmp(reg.name(), name.c_str()) == 0)
             return &reg;


### PR DESCRIPTION
A mutable version of `cpureg` is needed to access set and `cpureg::get_value()`, but `target` only gives const-access to `cpuregs`.

Makes sense to have a const version of `target::find_reg() `and `target::regs()` if access from a const `target` was needed. In the codebase, targets are only referenced from session, which has a static method for getting non-const access to all sessions. This would effectively make all cpuregs accessible from everywhere, but maybe you'd prefer proper encapsulation? Maybe target could have read_reg() and write_reg()? 