### PR TITLE
command/session: add time unit + non-blocking step function

### DIFF
--- a/include/vsp/command.h
+++ b/include/vsp/command.h
@@ -32,7 +32,7 @@ public:
     command& operator=(const command&) = delete;
 
     string execute(const vector<string>& args);
-    string execute(const string& args);
+    string execute(const string& args = "");
 
     const char* desc() const;
     size_t argc() const;

--- a/include/vsp/session.h
+++ b/include/vsp/session.h
@@ -61,8 +61,8 @@ public:
     void connect();
     void disconnect();
     void kill();
-    void step();
-    void step(u64 ns);
+    void step(bool block = true);
+    void step(u64 ns, bool block = true);
     void stepi(const target& t);
     void run();
     void stop();

--- a/include/vsp/session.h
+++ b/include/vsp/session.h
@@ -28,9 +28,9 @@ private:
     string m_vcml_version;
     bool m_running;
     string m_reason;
-    unsigned long long m_time;
+    unsigned long long m_time_ns;
     unsigned long long m_cycle;
-    int m_quantum;
+    int m_quantum_ns;
     module* m_mods;
     list<target> m_targets;
 
@@ -53,7 +53,7 @@ public:
     bool running();
     const string& sysc_version() const;
     const string& vcml_version() const;
-    unsigned long long time();
+    unsigned long long time_ns();
     unsigned long long cycle();
     const string& reason() const;
 
@@ -62,7 +62,7 @@ public:
     void disconnect();
     void kill();
     void step();
-    void step(u64 ps);
+    void step(u64 ns);
     void stepi(const target& t);
     void run();
     void stop();

--- a/src/cli/session.cpp
+++ b/src/cli/session.cpp
@@ -138,7 +138,7 @@ bool session::handle_info(const string& args) {
     print_report_line("VCML Version", m_session->vcml_version());
     print_report_line("SystemC Version", m_session->sysc_version());
     print_report_line("Simulation Time",
-                      mwr::mkstr("%.9f", m_session->time() / 1e9));
+                      mwr::mkstr("%.9fs", m_session->time_ns() / 1e9));
     print_report_line("Delta Cycle", to_string(m_session->cycle()));
     print_report_line("CLI Version", VSP_VERSION_STRING);
     return true;
@@ -203,7 +203,7 @@ bool session::handle_exec(const string& args) {
 string session::prompt() const {
     stringstream ss;
     ss << termcolors::BOLD << termcolors::WHITE << "[" << std::fixed
-       << std::setprecision(9) << m_session->time() / 1e9 << "s] "
+       << std::setprecision(9) << m_session->time_ns() / 1e9 << "s] "
        << termcolors::CLEAR;
     ss << termcolors::YELLOW << m_session->peer() << termcolors::CLEAR;
     ss << " " << termcolors::BOLD << termcolors::CYAN

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -178,19 +178,21 @@ void session::kill() {
     m_conn.command("quit");
 }
 
-void session::step() {
-    step(m_quantum_ns);
+void session::step(bool block) {
+    step(m_quantum_ns, block);
 }
 
-void session::step(u64 ns) {
+void session::step(u64 ns, bool block) {
     update_status();
     if (!m_running) {
         m_running = true;
         m_conn.command("resume," + to_string(ns) + "ns");
     }
 
-    while (m_running)
-        update_status();
+    if (block) {
+        while (m_running)
+            update_status();
+    }
 }
 
 void session::stepi(const target& t) {

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -25,9 +25,9 @@ session::session(const string& host, u16 port):
     m_vcml_version(),
     m_running(false),
     m_reason(),
-    m_time(0),
+    m_time_ns(0),
     m_cycle(0),
-    m_quantum(0),
+    m_quantum_ns(0),
     m_mods(nullptr),
     m_targets() {
 }
@@ -50,7 +50,7 @@ bool session::update_quantum() {
     if (!connection::check_response(resp, 2))
         return false;
 
-    m_quantum = stoi(resp->at(1));
+    m_quantum_ns = stoi(resp->at(1));
 
     return true;
 }
@@ -68,7 +68,7 @@ bool session::update_status() {
         m_reason = resp->at(1).substr(8);
     }
 
-    m_time = stoull(resp->at(2));
+    m_time_ns = stoull(resp->at(2));
     m_cycle = stoull(resp->at(3));
 
     return true;
@@ -132,9 +132,9 @@ const string& session::vcml_version() const {
     return m_vcml_version;
 }
 
-unsigned long long session::time() {
+unsigned long long session::time_ns() {
     update_status();
-    return m_time;
+    return m_time_ns;
 }
 
 unsigned long long session::cycle() {
@@ -179,14 +179,14 @@ void session::kill() {
 }
 
 void session::step() {
-    step(m_quantum);
+    step(m_quantum_ns);
 }
 
-void session::step(u64 ps) {
+void session::step(u64 ns) {
     update_status();
     if (!m_running) {
         m_running = true;
-        m_conn.command("resume," + to_string(ps) + "ps");
+        m_conn.command("resume," + to_string(ns) + "ns");
     }
 
     while (m_running)


### PR DESCRIPTION
* The vsp time unit is ns. I added the `_ns` postfix to time variable names to clarify the unit and changed the used unit of the `step` function from ps to ns to not used different units.
* The `session::step` function was blocking. It only returned after the step has been simulated. I added a parameter `block`. If `block` is set to `false`, the function directly returns and the status of the simulation can be queried using `bool session::running()`.