### PR TITLE
session: remove kill function

### DIFF
--- a/include/vsp/session.h
+++ b/include/vsp/session.h
@@ -60,7 +60,7 @@ public:
     bool is_connected() const;
     void connect();
     void disconnect();
-    void kill();
+    void quit();
     void step(bool block = true);
     void step(u64 ns, bool block = true);
     void stepi(const target& t);

--- a/src/cli/session.cpp
+++ b/src/cli/session.cpp
@@ -28,14 +28,12 @@ session::session(shared_ptr<vsp::session> s):
                      "executes the given <command> [args...]", "x");
     register_handler(&session::handle_info, "info",
                      "print information about the current session", "i");
-    register_handler(&session::handle_kill, "kill",
-                     "terminate current session", "k");
     register_handler(
         &session::handle_list, "list",
         "displays the module hierarchy onwards from current module", "ls");
     register_handler(&session::handle_quit, "quit", "disconnect from session",
                      "q");
-    register_handler(&session::handle_detach, "detach", "deatch from session",
+    register_handler(&session::handle_detach, "detach", "terminate session",
                      "d");
     register_handler(&session::handle_read, "read",
                      "reads the given <attribute>", "r");
@@ -167,18 +165,14 @@ bool session::handle_stop(const string& args) {
     return true;
 }
 
-bool session::handle_quit(const string& args) {
+bool session::handle_detach(const string& args) {
     m_session->disconnect();
     return false;
 }
 
-bool session::handle_detach(const string& args) {
-    return false;
-}
-
-bool session::handle_kill(const string& args) {
+bool session::handle_quit(const string& args) {
     try {
-        m_session->kill();
+        m_session->quit();
     } catch (const mwr::report&) {
     }
     cout << "exiting" << endl;

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -174,8 +174,13 @@ bool session::is_connected() const {
     return m_conn.is_connected();
 }
 
-void session::kill() {
-    m_conn.command("quit");
+void session::quit() {
+    try {
+        m_conn.command("quit");
+    } catch (mwr::report&) {
+        // excpect disconnect
+    }
+    disconnect();
 }
 
 void session::step(bool block) {


### PR DESCRIPTION
The kill command does not exist in the vsp. Instead, quit is used. Expect a disconnect during the execution of the quit command.