### PR TITLE
Fix string/char* bugs

### DIFF
--- a/include/vsp/target.h
+++ b/include/vsp/target.h
@@ -35,7 +35,7 @@ public:
     target(const target&) = delete;
     target& operator=(const target&) = delete;
 
-    const string& name() const;
+    const char* name() const;
 
     void step(size_t steps = 1);
     u64 virt_to_phys(u64 va);

--- a/src/vsp/cpureg.cpp
+++ b/src/vsp/cpureg.cpp
@@ -19,7 +19,8 @@ cpureg::cpureg(connection& conn, const string& name, target& parent):
 }
 
 bool cpureg::update_size() {
-    auto resp = m_conn.command("getr," + m_parent.name() + "," + m_name);
+    auto resp = m_conn.command("getr," + string(m_parent.name()) + "," +
+                               m_name);
     if (!resp)
         return false;
     if (resp->at(0) != "OK")
@@ -34,7 +35,8 @@ size_t cpureg::size() const {
 
 bool cpureg::get_value(vector<u8>& ret) {
     ret.clear();
-    auto resp = m_conn.command("getr," + m_parent.name() + "," + m_name);
+    auto resp = m_conn.command("getr," + string(m_parent.name()) + "," +
+                               m_name);
     if (!connection::check_response(resp, m_size + 1))
         return false;
 

--- a/src/vsp/module.cpp
+++ b/src/vsp/module.cpp
@@ -64,7 +64,7 @@ attribute* module::find_attribute(const string& name) {
     if (dot_pos == string::npos) {
         auto it = find_if(m_attrs.begin(), m_attrs.end(),
                           [&name](const class attribute* a) -> bool {
-                              return a->name() == name;
+                              return strcmp(a->name(), name.c_str()) == 0;
                           });
         if (it == m_attrs.end())
             return nullptr;
@@ -82,9 +82,10 @@ command* module::find_command(const string& name) {
     size_t dot_pos = name.find_last_of('.');
 
     if (dot_pos == string::npos) {
-        auto it = find_if(
-            m_cmds.begin(), m_cmds.end(),
-            [&name](const command* c) -> bool { return c->name() == name; });
+        auto it = find_if(m_cmds.begin(), m_cmds.end(),
+                          [&name](const command* c) -> bool {
+                              return strcmp(c->name(), name.c_str()) == 0;
+                          });
         if (it == m_cmds.end())
             return nullptr;
         return *it;

--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -213,7 +213,7 @@ void session::stepi(const target& t) {
     update_status();
     if (!m_running) {
         m_running = true;
-        m_conn.command("step," + t.name());
+        m_conn.command("step," + string(t.name()));
     }
 
     while (m_running)
@@ -264,7 +264,7 @@ command* session::find_command(const string& name) {
 
 target* session::find_target(const string& name) {
     for (auto& t : m_targets) {
-        if (t.name() == name)
+        if (strcmp(t.name(), name.c_str()) == 0)
             return &t;
     }
 

--- a/src/vsp/target.cpp
+++ b/src/vsp/target.cpp
@@ -33,8 +33,8 @@ bool target::update_regs() {
     return true;
 }
 
-const string& target::name() const {
-    return m_name;
+const char* target::name() const {
+    return m_name.c_str();
 }
 
 void target::step(size_t steps) {


### PR DESCRIPTION
I just noticed that there are some wrong string comparisons and inconsistencies that result from the return-type change from `const string&` to `const char*`