### PR TITLE
session: wait until stopped on connect

### DIFF
--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -168,6 +168,11 @@ void session::connect() {
     update_version();
     update_quantum();
     update_status();
+
+    stop();
+    while (running())
+        mwr::cpu_yield();
+
     update_modules();
 }
 


### PR DESCRIPTION
When connecting to a session, wait until the session is stopped. Otherwise, the module hierarchy cannot be read.