### PR TITLE
session: stop session before reading quantum

### DIFF
--- a/src/vsp/session.cpp
+++ b/src/vsp/session.cpp
@@ -311,13 +311,13 @@ void session::connect() {
         return;
 
     update_version();
-    update_quantum();
     update_status();
 
     stop();
     while (running())
         mwr::cpu_yield();
 
+    update_quantum();
     update_modules();
 }
 


### PR DESCRIPTION
If the quantum is read while the simulation is running, an error is returned.

See https://github.com/machineware-gmbh/vcml/blob/main/src/vcml/debugging/vspserver.cpp#L432-L434