### PR TITLE
tsan: adding suppression files + VSP_ENVVAR fix

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ macro(new_test test timeout)
     target_compile_options(${test} PRIVATE ${MWR_COMPILER_WARN_FLAGS})
     set_target_properties(${test} PROPERTIES CXX_CLANG_TIDY "${VSP_LINTER}")
     add_test(NAME ${test} COMMAND ${test})
-    set_tests_properties(${test} PROPERTIES ENVIRONMENT "{VSP_ENVVAR}")
+    set_tests_properties(${test} PROPERTIES ENVIRONMENT "${VSP_ENVVAR}")
     set_tests_properties(${test} PROPERTIES TIMEOUT ${timeout})
 endmacro()
 

--- a/test/sanitizer/tsan.suppress
+++ b/test/sanitizer/tsan.suppress
@@ -1,1 +1,23 @@
-# nothing to suppress
+# from_value_and_unit is called by most sc_time constructors and always writes
+# 'true' to 'time_resolution_fixed', unsynchronized from other threads
+race:from_value_and_unit
+race:from_value
+
+# `m_delta_count` is increased by crunch and read by other functions (e.g. "sc_delta_count")
+race:sc_core::sc_simcontext::crunch(bool)
+
+# the sc_time copy constructors reports a race on simcontext m_curr_time when
+# we call sc_time_stamp from threads other than the main SystemC thread
+race:sc_core::sc_time::operator=
+race:sc_core::sc_time::from_value_and_unit
+race:sc_core::sc_time::from_value
+race:sc_core::sc_time::sc_time
+
+# the async update list does not lock-protect its internal pending-requests
+# vector when checking if there are any pending requests via vector->size()
+race:sc_core::sc_prim_channel_registry::async_update_list::pending
+race:sc_core::sc_prim_channel_registry::async_update_list::append
+
+# fibers are considered as individual threads, and we call suspend() from the
+# main thread, but sometimes also from vcml processor SC_THREADS
+mutex:vcml::thctl::suspend


### PR DESCRIPTION
Adding TSAN suppressions for the SystemC kernel.
This will be needed for more elaborated session tests.
Also, fix wrong referencing of  `VSP_ENVVAR`  in CMakeLists.txt