### PR TITLE
target: specify cpureg size on creation

### DIFF
--- a/include/vsp/cpureg.h
+++ b/include/vsp/cpureg.h
@@ -29,7 +29,8 @@ private:
     bool update_size();
 
 public:
-    explicit cpureg(connection& conn, const string& name, target& m_parent);
+    explicit cpureg(connection& conn, const string& name, target& m_parent,
+                    size_t size = 0);
     virtual ~cpureg() = default;
 
     cpureg() = delete;

--- a/src/vsp/cpureg.cpp
+++ b/src/vsp/cpureg.cpp
@@ -13,9 +13,11 @@
 
 namespace vsp {
 
-cpureg::cpureg(connection& conn, const string& name, target& parent):
-    m_conn(conn), m_name(name), m_size(0), m_parent(parent) {
-    update_size();
+cpureg::cpureg(connection& conn, const string& name, target& parent,
+               size_t size):
+    m_conn(conn), m_name(name), m_size(size), m_parent(parent) {
+    if (m_size == 0)
+        update_size();
 }
 
 bool cpureg::update_size() {

--- a/src/vsp/target.cpp
+++ b/src/vsp/target.cpp
@@ -39,8 +39,17 @@ bool target::update_regs() {
     if (resp->at(0) != "OK")
         return false;
 
-    for (size_t i = 1; i < resp->size(); ++i)
-        m_regs.emplace_back(m_conn, resp->at(i), *this);
+    for (size_t i = 1; i < resp->size(); ++i) {
+        size_t regsize = 0;
+        const string& regname = resp->at(i);
+
+        size_t colon_pos = regname.find_last_of(':');
+        if (colon_pos != string::npos)
+            regsize = stoi(regname.substr(colon_pos + 1));
+
+        m_regs.emplace_back(m_conn, regname.substr(0, colon_pos), *this,
+                            regsize);
+    }
 
     return true;
 }


### PR DESCRIPTION
If supported by the vsp server, pass the reg size from the lreg command to the register during instatiation.

This removes the communication overhead (see machineware-gmbh/vsp#19).